### PR TITLE
Make it possible to not build DSSI plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,9 @@ clean:
 
 install:
 	install -d $(DESTDIR)$(PREFIX)/lib/ladspa/
+ifeq ($(BUILD_DSSI),true)
 	install -d $(DESTDIR)$(PREFIX)/lib/dssi/
+endif # BUILD_DSSI
 	install -d $(DESTDIR)$(PREFIX)/lib/lv2/
 	install -d $(DESTDIR)$(PREFIX)/lib/vst/
 	install -d $(DESTDIR)$(PREFIX)/lib/vst3/
@@ -172,14 +174,16 @@ install:
 	install -d $(DESTDIR)$(PREFIX)/bin/
 
 	install -m 644 bin/*-ladspa.* $(DESTDIR)$(PREFIX)/lib/ladspa/
+ifeq ($(BUILD_DSSI),true)
 	install -m 644 bin/*-dssi.*   $(DESTDIR)$(PREFIX)/lib/dssi/
+endif # BUILD_DSSI
 ifneq ($(MACOS),true)
 	install -m 644 bin/*-vst.*    $(DESTDIR)$(PREFIX)/lib/vst/
 endif
 
-ifeq ($(HAVE_CAIRO_OR_OPENGL),true)
+ifeq ($(BUILD_DSSI),true)
 	cp -r  bin/*-dssi $(DESTDIR)$(PREFIX)/lib/dssi/
-endif # HAVE_CAIRO_OR_OPENGL
+endif # BUILD_DSSI
 	cp -rL bin/*.lv2  $(DESTDIR)$(PREFIX)/lib/lv2/
 ifeq ($(HAVE_OPENGL),true)
 	cp -rL bin/*.vst  $(DESTDIR)$(PREFIX)/lib/vst/

--- a/dpf/Makefile.base.mk
+++ b/dpf/Makefile.base.mk
@@ -555,6 +555,15 @@ BUILD_CXX_FLAGS += -DDGL_NAMESPACE=$(DGL_NAMESPACE)
 endif
 
 # ---------------------------------------------------------------------------------------------------------------------
+# Which plugin types to build
+
+ifeq ($(HAVE_CAIRO_OR_OPENGL),true)
+ifeq ($(HAVE_LIBLO),true)
+BUILD_DSSI = true
+endif
+endif
+
+# ---------------------------------------------------------------------------------------------------------------------
 # Optional flags
 
 ifeq ($(NVG_DISABLE_SKIPPING_WHITESPACE),true)

--- a/dpf/Makefile.plugins.mk
+++ b/dpf/Makefile.plugins.mk
@@ -299,7 +299,7 @@ DGL_LIBS =
 OBJS_UI =
 endif
 
-ifneq ($(HAVE_LIBLO),true)
+ifneq ($(BUILD_DSSI),true)
 dssi_ui =
 endif
 

--- a/plugins/3BandEQ/Makefile
+++ b/plugins/3BandEQ/Makefile
@@ -31,10 +31,8 @@ include ../../dpf/Makefile.plugins.mk
 
 TARGETS = jack ladspa lv2_sep vst2 vst3 clap
 
-ifeq ($(HAVE_CAIRO_OR_OPENGL),true)
-ifeq ($(HAVE_LIBLO),true)
+ifeq ($(BUILD_DSSI),true)
 TARGETS += dssi
-endif
 endif
 
 all: $(TARGETS)

--- a/plugins/3BandSplitter/Makefile
+++ b/plugins/3BandSplitter/Makefile
@@ -31,10 +31,8 @@ include ../../dpf/Makefile.plugins.mk
 
 TARGETS = jack ladspa lv2_sep vst2 vst3 clap
 
-ifeq ($(HAVE_CAIRO_OR_OPENGL),true)
-ifeq ($(HAVE_LIBLO),true)
+ifeq ($(BUILD_DSSI),true)
 TARGETS += dssi
-endif
 endif
 
 all: $(TARGETS)

--- a/plugins/AmplitudeImposer/Makefile
+++ b/plugins/AmplitudeImposer/Makefile
@@ -36,10 +36,8 @@ TARGETS += lv2_sep
 TARGETS += vst2
 TARGETS += vst3
 
-ifeq ($(HAVE_CAIRO_OR_OPENGL),true)
-ifeq ($(HAVE_LIBLO),true)
+ifeq ($(BUILD_DSSI),true)
 TARGETS += dssi
-endif
 endif
 
 all: $(TARGETS)

--- a/plugins/CycleShifter/Makefile
+++ b/plugins/CycleShifter/Makefile
@@ -36,10 +36,8 @@ TARGETS += lv2_sep
 TARGETS += vst2
 TARGETS += vst3
 
-ifeq ($(HAVE_CAIRO_OR_OPENGL),true)
-ifeq ($(HAVE_LIBLO),true)
+ifeq ($(BUILD_DSSI),true)
 TARGETS += dssi
-endif
 endif
 
 all: $(TARGETS)

--- a/plugins/Kars/Makefile
+++ b/plugins/Kars/Makefile
@@ -23,6 +23,12 @@ include ../../dpf/Makefile.plugins.mk
 # --------------------------------------------------------------
 # Enable all possible plugin types
 
-all: jack dssi_dsp lv2_dsp vst2 vst3 clap
+TARGETS = jack lv2_dsp vst2 vst3 clap
+
+ifeq ($(BUILD_DSSI),true)
+TARGETS += dssi_dsp
+endif
+
+all: $(TARGETS)
 
 # --------------------------------------------------------------

--- a/plugins/MVerb/Makefile
+++ b/plugins/MVerb/Makefile
@@ -30,10 +30,8 @@ include ../../dpf/Makefile.plugins.mk
 
 TARGETS = jack ladspa lv2_sep vst2 vst3 clap
 
-ifeq ($(HAVE_DGL),true)
-ifeq ($(HAVE_LIBLO),true)
+ifeq ($(BUILD_DSSI),true)
 TARGETS += dssi
-endif
 endif
 
 all: $(TARGETS)

--- a/plugins/Nekobi/Makefile
+++ b/plugins/Nekobi/Makefile
@@ -35,6 +35,12 @@ LINK_FLAGS += -pthread
 # --------------------------------------------------------------
 # Enable all possible plugin types
 
-all: jack dssi lv2_sep vst2 vst3 clap
+TARGETS = jack lv2_sep vst2 vst3 clap
+
+ifeq ($(BUILD_DSSI),true)
+TARGETS += dssi
+endif
+
+all: $(TARGETS)
 
 # --------------------------------------------------------------

--- a/plugins/PingPongPan/Makefile
+++ b/plugins/PingPongPan/Makefile
@@ -31,10 +31,8 @@ include ../../dpf/Makefile.plugins.mk
 
 TARGETS = jack ladspa lv2_sep vst2 vst3 clap
 
-ifeq ($(HAVE_CAIRO_OR_OPENGL),true)
-ifeq ($(HAVE_LIBLO),true)
+ifeq ($(BUILD_DSSI),true)
 TARGETS += dssi
-endif
 endif
 
 all: $(TARGETS)

--- a/plugins/SoulForce/Makefile
+++ b/plugins/SoulForce/Makefile
@@ -36,10 +36,8 @@ TARGETS += lv2_sep
 TARGETS += vst2
 TARGETS += vst3
 
-ifeq ($(HAVE_CAIRO_OR_OPENGL),true)
-ifeq ($(HAVE_LIBLO),true)
+ifeq ($(BUILD_DSSI),true)
 TARGETS += dssi
-endif
 endif
 
 all: $(TARGETS)


### PR DESCRIPTION
I'm not sure if this is the best way to fix this, but it seems to work OK...

If `HAVE_LIBLO` wasn't true, then DSSI plugins would (mostly) not be built, but the install rule would still try to install them and fail. Add a `BUILD_DSSI` variable, so the test for whether DSSI is supported is done in one place, and check it in the install rule.