### PR TITLE
Fix 3BandEQ, 3BandSplitter, and PingPongPan CLAP IDs

### DIFF
--- a/plugins/3BandEQ/DistrhoPluginInfo.h
+++ b/plugins/3BandEQ/DistrhoPluginInfo.h
@@ -20,7 +20,7 @@
 #define DISTRHO_PLUGIN_BRAND   "DISTRHO"
 #define DISTRHO_PLUGIN_NAME    "3 Band EQ"
 #define DISTRHO_PLUGIN_URI     "http://distrho.sf.net/plugins/3BandEQ"
-#define DISTRHO_PLUGIN_CLAP_ID "studio.kx.distrho.MVerb"
+#define DISTRHO_PLUGIN_CLAP_ID "studio.kx.distrho.3BandEQ"
 
 #define DISTRHO_PLUGIN_HAS_UI        1
 #define DISTRHO_PLUGIN_IS_RT_SAFE    1

--- a/plugins/3BandSplitter/DistrhoPluginInfo.h
+++ b/plugins/3BandSplitter/DistrhoPluginInfo.h
@@ -20,7 +20,7 @@
 #define DISTRHO_PLUGIN_BRAND   "DISTRHO"
 #define DISTRHO_PLUGIN_NAME    "3 Band Splitter"
 #define DISTRHO_PLUGIN_URI     "http://distrho.sf.net/plugins/3BandSplitter"
-#define DISTRHO_PLUGIN_CLAP_ID "studio.kx.distrho.MVerb"
+#define DISTRHO_PLUGIN_CLAP_ID "studio.kx.distrho.3BandSplitter"
 
 #define DISTRHO_PLUGIN_HAS_UI        1
 #define DISTRHO_PLUGIN_IS_RT_SAFE    1

--- a/plugins/PingPongPan/DistrhoPluginInfo.h
+++ b/plugins/PingPongPan/DistrhoPluginInfo.h
@@ -20,7 +20,7 @@
 #define DISTRHO_PLUGIN_BRAND   "DISTRHO"
 #define DISTRHO_PLUGIN_NAME    "Ping Pong Pan"
 #define DISTRHO_PLUGIN_URI     "http://distrho.sf.net/plugins/PingPongPan"
-#define DISTRHO_PLUGIN_CLAP_ID "studio.kx.distrho.MVerb"
+#define DISTRHO_PLUGIN_CLAP_ID "studio.kx.distrho.PingPongPan"
 
 #define DISTRHO_PLUGIN_HAS_UI        1
 #define DISTRHO_PLUGIN_IS_RT_SAFE    1


### PR DESCRIPTION
The 3BandEQ, 3BandSplitter, and PingPongPan plugins were mistakenly using the same CLAP ID as MVerb.